### PR TITLE
release/2.3.4

### DIFF
--- a/.claude/skills/commit-and-push/SKILL.md
+++ b/.claude/skills/commit-and-push/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: commit-and-push
+description: Commit staged/unstaged changes and push to the remote. Use when the user asks to commit, push, or "commit and push" their work. Enforces small conventional commit messages, the current branch, and no co-author attribution.
+---
+
+# Commit and Push
+
+Follow these rules when committing and pushing.
+
+## Rules
+
+1. **Current branch** — always commit and push to the current branch, unless the user tells you otherwise. Do not create or switch branches on your own.
+2. **No co-author** — never add yourself (Claude) as a co-author. Do not append any `Co-Authored-By` trailer or "Generated with Claude Code" line.
+3. **Message format** — keep it small and use `<type>: brief description`, where `<type>` is one of `feat` / `fix` / `chore`. Example: `feat: player damage feedback`.
+
+## Steps
+
+1. Run `git status` and `git diff` to review what will be committed.
+2. Stage the changes (`git add`).
+3. Commit with a message in the required format. Pick the `<type>` that matches the change:
+   - `feat` — a new feature or capability.
+   - `fix` — a bug fix.
+   - `chore` — tooling, config, refactors, or maintenance that isn't a feature or fix.
+4. Push to the current branch: `git push`.
+
+## Example
+
+```
+git add .
+git commit -m "fix: local storage initialization"
+git push
+```

--- a/bundles/angry-pixel/package.json
+++ b/bundles/angry-pixel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "angry-pixel",
-    "version": "2.3.3",
+    "version": "2.3.4",
     "description": "Lightweight 2D game engine made with TypeScript.",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/demos/dev/src/entity/Foreground.ts
+++ b/demos/dev/src/entity/Foreground.ts
@@ -27,7 +27,6 @@ export const foregroundArchetype: Archetype = {
                 image: ASSETS.images.tileset,
                 tileWidth: 16,
                 tileHeight: 16,
-                width: 12,
             },
             layer: RENDER_LAYERS.Foreground,
         }),

--- a/docs/en/manual/built-in-components/tiled-wrapper.md
+++ b/docs/en/manual/built-in-components/tiled-wrapper.md
@@ -23,7 +23,6 @@ this.entityManager.createEntity([
         layer: "Foreground",
         tileset: {
             image: this.assetManager.getImage("tileset.png"),
-            width: 8,
             tileWidth: 16,
             tileHeight: 16,
         },

--- a/docs/en/manual/built-in-components/tilemap-collider.md
+++ b/docs/en/manual/built-in-components/tilemap-collider.md
@@ -26,7 +26,6 @@ this.entityManager.createEntity([
     new TilemapRenderer({
         tileset: {
             image: this.assetManager.getImage("tileset.png"),
-            width: 8,
             tileWidth: 16,
             tileHeight: 16,
         },

--- a/docs/en/manual/built-in-components/tilemap-renderer.md
+++ b/docs/en/manual/built-in-components/tilemap-renderer.md
@@ -21,22 +21,33 @@ Each tile is referenced by an ID, where `0` represents empty space. The tile dat
 | `maskColor` | `string` | — | Mask color applied to the tiles. |
 | `maskColorMix` | `number` | — | Mask color opacity between `0` and `1`. |
 | `smooth` | `boolean` | `false` | Smooths pixels. Not recommended for pixel art. |
-| `animations` | `Map<number, TileAnimation>` | empty | Animated tiles, keyed by the tile ID to animate (see below). |
 
 ### Tileset
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `image` | `HTMLImageElement \| string` | The tileset image, or an asset URL/name string. |
-| `width` | `number` | Tileset width in tiles. |
 | `tileWidth` | `number` | Tile width in pixels. |
 | `tileHeight` | `number` | Tile height in pixels. |
-| `margin` | `Vector2` | Optional margin (top and left) in pixels. |
-| `spacing` | `Vector2` | Optional spacing (bottom and right) in pixels. |
+| `margin` | `number` | Space in pixels between the tiles and the four edges of the image. Defaults to `0`. |
+| `spacing` | `number` | Space in pixels between adjacent tiles. Defaults to `0`. |
+| `animations` | `Map<number, TileAnimation>` | Animated tiles, keyed by the tile ID to animate (see below). |
+
+For a tileset whose tiles are extruded by 1 pixel, the image has a margin of `1` and a spacing of `2`:
+
+```typescript
+tileset: {
+    image: this.assetManager.getImage("tileset.png"),
+    tileWidth: 16,
+    tileHeight: 16,
+    margin: 1,
+    spacing: 2,
+}
+```
 
 ### Tile animations
 
-A `TileAnimation` cycles a tile through a sequence of tileset tile IDs. The `animations` map is keyed by the tile ID that should animate: every tile in the map with that ID plays the animation. Animations always loop.
+A `TileAnimation` cycles a tile through a sequence of tileset tile IDs. The `animations` map is defined in the tileset and is keyed by the tile ID that should animate: every tile with that ID plays the animation. Since the animations belong to the tileset, every tilemap using that tileset plays them in sync. Animations always loop.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -54,7 +65,6 @@ this.entityManager.createEntity([
         layer: "Default",
         tileset: {
             image: this.assetManager.getImage("tileset.png"),
-            width: 8,
             tileWidth: 16,
             tileHeight: 16,
         },
@@ -75,15 +85,14 @@ this.entityManager.createEntity([
     new TilemapRenderer({
         tileset: {
             image: this.assetManager.getImage("tileset.png"),
-            width: 8,
             tileWidth: 16,
             tileHeight: 16,
+            // Every tile with ID 3 cycles through 3, 4, 5 at 6 fps.
+            animations: new Map([[3, new TileAnimation({ tiles: [3, 4, 5], fps: 6 })]]),
         },
         data: [1, 2, 3, 4],
         width: 2,
         height: 2,
-        // Every tile with ID 3 cycles through 3, 4, 5 at 6 fps.
-        animations: new Map([[3, new TileAnimation({ tiles: [3, 4, 5], fps: 6 })]]),
     }),
 ]);
 ```

--- a/docs/es/manual/built-in-components/tiled-wrapper.md
+++ b/docs/es/manual/built-in-components/tiled-wrapper.md
@@ -23,7 +23,6 @@ this.entityManager.createEntity([
         layer: "Foreground",
         tileset: {
             image: this.assetManager.getImage("tileset.png"),
-            width: 8,
             tileWidth: 16,
             tileHeight: 16,
         },

--- a/docs/es/manual/built-in-components/tilemap-collider.md
+++ b/docs/es/manual/built-in-components/tilemap-collider.md
@@ -26,7 +26,6 @@ this.entityManager.createEntity([
     new TilemapRenderer({
         tileset: {
             image: this.assetManager.getImage("tileset.png"),
-            width: 8,
             tileWidth: 16,
             tileHeight: 16,
         },

--- a/docs/es/manual/built-in-components/tilemap-renderer.md
+++ b/docs/es/manual/built-in-components/tilemap-renderer.md
@@ -21,22 +21,33 @@ Cada tile se referencia mediante un ID, donde `0` representa espacio vacío. Los
 | `maskColor` | `string` | — | Color de máscara aplicado a los tiles. |
 | `maskColorMix` | `number` | — | Opacidad del color de máscara entre `0` y `1`. |
 | `smooth` | `boolean` | `false` | Suaviza los píxeles. No recomendado para pixel art. |
-| `animations` | `Map<number, TileAnimation>` | vacío | Tiles animados, indexados por el ID del tile a animar (ver más abajo). |
 
 ### Tileset
 
 | Campo | Tipo | Descripción |
 |-------|------|-------------|
 | `image` | `HTMLImageElement \| string` | La imagen del tileset, o una cadena con la URL/nombre del recurso. |
-| `width` | `number` | Ancho del tileset en tiles. |
 | `tileWidth` | `number` | Ancho del tile en píxeles. |
 | `tileHeight` | `number` | Alto del tile en píxeles. |
-| `margin` | `Vector2` | Margen opcional (arriba e izquierda) en píxeles. |
-| `spacing` | `Vector2` | Espaciado opcional (abajo y derecha) en píxeles. |
+| `margin` | `number` | Espacio en píxeles entre los tiles y los cuatro bordes de la imagen. Por defecto `0`. |
+| `spacing` | `number` | Espacio en píxeles entre tiles adyacentes. Por defecto `0`. |
+| `animations` | `Map<number, TileAnimation>` | Tiles animados, indexados por el ID del tile a animar (ver más abajo). |
+
+Para un tileset cuyos tiles están extruidos 1 píxel, la imagen tiene un margen de `1` y un espaciado de `2`:
+
+```typescript
+tileset: {
+    image: this.assetManager.getImage("tileset.png"),
+    tileWidth: 16,
+    tileHeight: 16,
+    margin: 1,
+    spacing: 2,
+}
+```
 
 ### Animaciones de tiles
 
-Un `TileAnimation` hace que un tile recorra una secuencia de IDs de tile del tileset. El mapa `animations` se indexa por el ID del tile que debe animarse: todos los tiles del mapa con ese ID reproducen la animación. Las animaciones siempre se repiten en bucle.
+Un `TileAnimation` hace que un tile recorra una secuencia de IDs de tile del tileset. El mapa `animations` se define en el tileset y se indexa por el ID del tile que debe animarse: todos los tiles con ese ID reproducen la animación. Como las animaciones pertenecen al tileset, todos los tilemaps que lo usan las reproducen sincronizadas. Las animaciones siempre se repiten en bucle.
 
 | Opción | Tipo | Valor por defecto | Descripción |
 |--------|------|---------|-------------|
@@ -54,7 +65,6 @@ this.entityManager.createEntity([
         layer: "Default",
         tileset: {
             image: this.assetManager.getImage("tileset.png"),
-            width: 8,
             tileWidth: 16,
             tileHeight: 16,
         },
@@ -75,15 +85,14 @@ this.entityManager.createEntity([
     new TilemapRenderer({
         tileset: {
             image: this.assetManager.getImage("tileset.png"),
-            width: 8,
             tileWidth: 16,
             tileHeight: 16,
+            // Cada tile con ID 3 recorre 3, 4, 5 a 6 fps.
+            animations: new Map([[3, new TileAnimation({ tiles: [3, 4, 5], fps: 6 })]]),
         },
         data: [1, 2, 3, 4],
         width: 2,
         height: 2,
-        // Cada tile con ID 3 recorre 3, 4, 5 a 6 fps.
-        animations: new Map([[3, new TileAnimation({ tiles: [3, 4, 5], fps: 6 })]]),
     }),
 ]);
 ```

--- a/packages/engine/src/component/render2d/TilemapRenderer.ts
+++ b/packages/engine/src/component/render2d/TilemapRenderer.ts
@@ -1,4 +1,3 @@
-import { Vector2 } from "@angry-pixel/math";
 import { defaultRenderLayer } from "./Camera";
 import { TilemapRenderData } from "@angry-pixel/webgl";
 
@@ -12,11 +11,10 @@ import { TilemapRenderData } from "@angry-pixel/webgl";
  *   layer: "Default",
  *   tileset: {
  *     image: this.assetManager.getImage("tileset.png"),
- *     width: 10,
  *     tileWidth: 32,
  *     tileHeight: 32,
- *     margin: new Vector2(0, 0),
- *     spacing: new Vector2(0, 0)
+ *     margin: 0,
+ *     spacing: 0
  *   },
  *   data: [1, 2, 3, 4],
  *   chunks: [],
@@ -46,7 +44,6 @@ export interface TilemapRendererOptions {
     maskColorMix: number;
     opacity: number;
     smooth: boolean;
-    animations: Map<number, TileAnimation>;
 }
 
 /**
@@ -63,11 +60,10 @@ export interface TilemapRendererOptions {
  *   layer: "Default",
  *   tileset: {
  *     image: this.assetManager.getImage("tileset.png"),
- *     width: 10,
  *     tileWidth: 32,
  *     tileHeight: 32,
- *     margin: new Vector2(0, 0),
- *     spacing: new Vector2(0, 0)
+ *     margin: 0,
+ *     spacing: 0
  *   },
  *   data: [1, 2, 3, 4],
  *   chunks: [],
@@ -110,15 +106,11 @@ export class TilemapRenderer {
     maskColorMix: number;
     /** TRUE for smooth pixels (not recommended for pixel art) */
     smooth: boolean = false;
-    /** Animated tiles, keyed by the tile id to animate. */
-    animations: Map<number, TileAnimation> = new Map();
 
     /** @internal */
     _processed: boolean = false;
     /** @internal */
     _renderData: TilemapRenderData[] = [];
-    /** Maps each animated tile id to the tile id currently displayed. @internal */
-    _tileAnimationState: Map<number, number> = new Map();
     /** @internal */
     static componentName: string = "TilemapRenderer";
 
@@ -146,18 +138,23 @@ export interface TileAnimationOptions {
 
 /**
  * TileAnimation cycles a tile through a sequence of tile ids from the tileset.\
- * It is assigned to a {@link TilemapRenderer} keyed by the tile id that should animate.
+ * It is assigned to a {@link Tileset} keyed by the tile id that should animate,\
+ * so every tilemap using that tileset plays the animation in sync.
  * @public
  * @category Components Configuration
  * @example
  * ```js
  * const tilemapRenderer = new TilemapRenderer({
- *   tileset: { image: "tileset.png", width: 10, tileWidth: 32, tileHeight: 32 },
+ *   tileset: {
+ *     image: "tileset.png",
+ *     tileWidth: 32,
+ *     tileHeight: 32,
+ *     animations: new Map([
+ *       [3, new TileAnimation({ tiles: [3, 4, 5], fps: 6 })]
+ *     ])
+ *   },
  *   data: [1, 2, 3, 4],
- *   width: 2,
- *   animations: new Map([
- *     [3, new TileAnimation({ tiles: [3, 4, 5], fps: 6 })]
- *   ])
+ *   width: 2
  * });
  * ```
  */
@@ -181,25 +178,38 @@ export class TileAnimation {
 
 /**
  * The Tileset configuration defines the properties of a tileset used by the TilemapRenderer.\
- * It specifies the source image containing the tiles, the dimensions of the tileset and individual tiles,\
- * and optional margin and spacing between tiles. This configuration is essential for properly\
- * slicing and rendering tiles from the tileset image.
+ * It specifies the source image containing the tiles, the size of the individual tiles,\
+ * and the optional margin and spacing of the image. The number of columns of the tileset\
+ * is obtained from the image. The tileset cannot be updated at runtime.
  * @public
  * @category Components Configuration
+ * @example
+ * ```js
+ * // a tileset of 16x16 tiles extruded by 1 pixel
+ * const tileset = {
+ *   image: this.assetManager.getImage("tileset.png"),
+ *   tileWidth: 16,
+ *   tileHeight: 16,
+ *   margin: 1,
+ *   spacing: 2
+ * };
+ * ```
  */
 export type Tileset = {
     /** The tileset image element */
     image: HTMLImageElement | string;
-    /* The width of tileset (in tiles) */
-    width: number;
     /* The width of the tile (in pixels) */
     tileWidth: number;
     /* The height of the tile (in pixels) */
     tileHeight: number;
-    /** Margin of the tile in pixels (space in the top and the left) */
-    margin?: Vector2;
-    /** Spacing of the tile in pixels (space in the bottom and the right) */
-    spacing?: Vector2;
+    /** Space in pixels between the tiles and the four edges of the image */
+    margin?: number;
+    /** Space in pixels between adjacent tiles */
+    spacing?: number;
+    /** Animated tiles, keyed by the tile id to animate */
+    animations?: Map<number, TileAnimation>;
+    /** Maps each animated tile id to the tile id currently displayed. @internal */
+    _animationState?: Map<number, number>;
 };
 
 /**

--- a/packages/engine/src/system/render2d/TilemapAnimationSystem.ts
+++ b/packages/engine/src/system/render2d/TilemapAnimationSystem.ts
@@ -1,4 +1,4 @@
-import { TileAnimation, TilemapRenderer } from "@component/render2d/TilemapRenderer";
+import { TileAnimation, TilemapRenderer, Tileset } from "@component/render2d/TilemapRenderer";
 import { SYSTEM_SYMBOLS } from "@config/systemSymbols";
 import { SYMBOLS } from "@config/dependencySymbols";
 import { EntityManager, System } from "@angry-pixel/ecs";
@@ -7,24 +7,39 @@ import { TimeManager } from "@manager/TimeManager";
 
 @injectable(SYSTEM_SYMBOLS.TilemapAnimationSystem)
 export class TilemapAnimationSystem implements System {
+    // a tileset can be shared by several tilemaps, so its animations are advanced only once per frame
+    private tilesets: Set<Tileset> = new Set();
+
     constructor(
         @inject(SYMBOLS.EntityManager) private readonly entityManager: EntityManager,
         @inject(SYMBOLS.TimeManager) private readonly timeManager: TimeManager,
     ) {}
 
     public onUpdate(): void {
-        this.entityManager.search(TilemapRenderer, (tilemapRenderer) => {
-            // drop state for tiles whose animation was removed, otherwise their last frame would render forever
-            tilemapRenderer._tileAnimationState.forEach((_, tile) => {
-                if (!tilemapRenderer.animations.has(tile)) tilemapRenderer._tileAnimationState.delete(tile);
-            });
+        this.tilesets.clear();
+        this.entityManager.search(TilemapRenderer, ({ tileset }) => {
+            if (tileset) this.tilesets.add(tileset);
+        });
 
-            if (tilemapRenderer.animations.size === 0) return;
+        this.tilesets.forEach((tileset) => this.updateTileset(tileset));
+    }
 
-            tilemapRenderer.animations.forEach((animation, tile) => {
-                this.advance(animation);
-                tilemapRenderer._tileAnimationState.set(tile, animation.tiles[animation.currentFrame]);
-            });
+    private updateTileset(tileset: Tileset): void {
+        if (!tileset.animations || tileset.animations.size === 0) {
+            tileset._animationState?.clear();
+            return;
+        }
+
+        if (!tileset._animationState) tileset._animationState = new Map();
+
+        // drop state for tiles whose animation was removed, otherwise their last frame would render forever
+        tileset._animationState.forEach((_, tile) => {
+            if (!tileset.animations.has(tile)) tileset._animationState.delete(tile);
+        });
+
+        tileset.animations.forEach((animation, tile) => {
+            this.advance(animation);
+            tileset._animationState.set(tile, animation.tiles[animation.currentFrame]);
         });
     }
 

--- a/packages/engine/src/system/render2d/TilemapRendererSystem.ts
+++ b/packages/engine/src/system/render2d/TilemapRendererSystem.ts
@@ -49,8 +49,6 @@ export class TilemapRendererSystem implements System {
                 renderData.tilemap.realHeight = renderData.tilemap.height * renderData.tilemap.tileHeight;
 
                 renderData.tiles = chunk.data;
-                renderData.tileAnimations =
-                    tilemapRenderer._tileAnimationState.size > 0 ? tilemapRenderer._tileAnimationState : undefined;
                 renderData.tileset = tilemapRenderer.tileset as Tileset;
                 renderData.opacity = tilemapRenderer.opacity;
                 renderData.rotation = transform.localRotation;

--- a/packages/webgl/src/renderer/TilemapRenderer.ts
+++ b/packages/webgl/src/renderer/TilemapRenderer.ts
@@ -20,7 +20,6 @@ export interface TilemapRenderData extends RenderData {
     tiles: number[];
     tilemap: Tilemap;
     tileset: Tileset;
-    tileAnimations?: Map<number, number>;
     smooth?: boolean;
     flipHorizontal?: boolean;
     flipVertical?: boolean;
@@ -34,12 +33,31 @@ export interface TilemapRenderData extends RenderData {
 
 export type Tileset = {
     image: HTMLImageElement;
-    width: number;
     tileWidth: number;
     tileHeight: number;
-    margin?: Vector2;
-    spacing?: Vector2;
-    correction?: Vector2;
+    /** Space in pixels between the tiles and the four edges of the image */
+    margin?: number;
+    /** Space in pixels between adjacent tiles */
+    spacing?: number;
+    /** Maps each animated tile id to the tile id currently displayed. @internal */
+    _animationState?: Map<number, number>;
+    /** Tileset values in texture coordinates. Computed once by the renderer. @internal */
+    _texData?: TilesetTexData;
+};
+
+/**
+ * Tileset values expressed in texture coordinates (0 to 1), plus the number of columns of the tileset.
+ * @internal
+ */
+type TilesetTexData = {
+    /** The width of the tileset (in tiles) */
+    columns: number;
+    /** The margin of the image */
+    margin: Vector2;
+    /** The distance between the origin of two adjacent tiles */
+    step: Vector2;
+    /** The size of a tile */
+    tileSize: Vector2;
 };
 
 export type Tilemap = {
@@ -64,16 +82,6 @@ export class TilemapRenderer implements Renderer {
 
     // cache
     private lastTexture: WebGLTexture = null;
-    private tileset = {
-        width: 0,
-        tileWidth: 0,
-        tileHeight: 0,
-        texMargin: new Vector2(),
-        texSpacing: new Vector2(),
-        texWidth: 0,
-        texHeight: 0,
-        texCorrection: new Vector2(),
-    };
 
     constructor(
         private readonly gl: WebGL2RenderingContext,
@@ -90,7 +98,7 @@ export class TilemapRenderer implements Renderer {
     public render(renderData: TilemapRenderData, cameraData: CameraData, lastRender?: RenderDataType): boolean {
         if (renderData.tiles.reduce((acc, tile) => acc + tile, 0) === 0) return false;
 
-        this.processTileset(renderData);
+        this.processTileset(renderData.tileset);
         this.generateVertices(renderData);
 
         if (this.posVertices.length === 0) return false;
@@ -115,12 +123,8 @@ export class TilemapRenderer implements Renderer {
             1,
         ]);
 
+        // the texture vertices are already expressed in texture coordinates
         this.textureMatrix = mat4.identity(this.textureMatrix);
-        mat4.scale(this.textureMatrix, this.textureMatrix, [
-            this.tileset.tileWidth / renderData.tileset.image.naturalWidth,
-            this.tileset.tileHeight / renderData.tileset.image.naturalHeight,
-            1,
-        ]);
 
         setProjectionMatrix(this.projectionMatrix, this.gl, cameraData.zoom, cameraData.position);
 
@@ -159,44 +163,39 @@ export class TilemapRenderer implements Renderer {
         return true;
     }
 
-    private processTileset({ tileset }: TilemapRenderData): void {
-        tileset.margin = tileset.margin ?? new Vector2();
-        tileset.spacing = tileset.spacing ?? new Vector2();
-        tileset.correction = tileset.correction ?? new Vector2();
+    /**
+     * Translates the tileset into texture coordinates. Since the tileset cannot be updated at runtime,\
+     * the result is cached in the tileset object and computed only once.
+     */
+    private processTileset(tileset: Tileset): void {
+        if (tileset._texData) return;
 
-        this.tileset.width = tileset.width;
-        this.tileset.tileWidth = tileset.tileWidth + (tileset.margin.x ?? 0) + (tileset.spacing.x ?? 0);
-        this.tileset.tileHeight = tileset.tileHeight + (tileset.margin.y ?? 0) + (tileset.spacing.y ?? 0);
+        const { naturalWidth, naturalHeight } = tileset.image;
+        const margin = tileset.margin ?? 0;
+        const spacing = tileset.spacing ?? 0;
 
-        this.tileset.texMargin.set(
-            tileset.margin.x / this.tileset.tileWidth,
-            tileset.margin.y / this.tileset.tileHeight,
-        );
-        this.tileset.texSpacing.set(
-            tileset.spacing.x / this.tileset.tileWidth,
-            tileset.spacing.y / this.tileset.tileHeight,
-        );
-        this.tileset.texCorrection.set(
-            tileset.correction.x / this.tileset.tileWidth,
-            tileset.correction.y / this.tileset.tileHeight,
-        );
-
-        this.tileset.texWidth =
-            1 - this.tileset.texMargin.x - this.tileset.texSpacing.x - 2 * this.tileset.texCorrection.x;
-        this.tileset.texHeight =
-            1 - this.tileset.texMargin.y - this.tileset.texSpacing.y - 2 * this.tileset.texCorrection.y;
+        tileset._texData = {
+            columns: Math.floor((naturalWidth - 2 * margin + spacing) / (tileset.tileWidth + spacing)),
+            margin: new Vector2(margin / naturalWidth, margin / naturalHeight),
+            step: new Vector2(
+                (tileset.tileWidth + spacing) / naturalWidth,
+                (tileset.tileHeight + spacing) / naturalHeight,
+            ),
+            tileSize: new Vector2(tileset.tileWidth / naturalWidth, tileset.tileHeight / naturalHeight),
+        };
     }
 
-    private generateVertices({ tiles, tilemap, tileAnimations }: TilemapRenderData): void {
+    private generateVertices({ tiles, tilemap, tileset }: TilemapRenderData): void {
         this.posVertices = [];
         this.texVertices = [];
 
+        const { columns, margin, step, tileSize } = tileset._texData;
         const height = Math.floor(tiles.length / tilemap.width);
 
         tiles.forEach((tile, tilemapTile) => {
             if (tile === 0) return;
 
-            const tilesetTile = tileAnimations?.get(tile) ?? tile;
+            const tilesetTile = tileset._animationState?.get(tile) ?? tile;
 
             const px = (tilemapTile % tilemap.width) - tilemap.width / 2;
             const py = height / 2 - Math.floor(tilemapTile / tilemap.width);
@@ -211,21 +210,17 @@ export class TilemapRenderer implements Renderer {
                 px + 1, py
             )
 
-            const tx =
-                ((tilesetTile - 1) % this.tileset.width) + this.tileset.texMargin.x + this.tileset.texCorrection.x;
-            const ty =
-                Math.floor((tilesetTile - 1) / this.tileset.width) +
-                this.tileset.texMargin.y +
-                this.tileset.texCorrection.y;
+            const tx = margin.x + ((tilesetTile - 1) % columns) * step.x;
+            const ty = margin.y + Math.floor((tilesetTile - 1) / columns) * step.y;
 
             // prettier-ignore
-            this.texVertices.push( 
-                tx, ty + this.tileset.texHeight,
-                tx + this.tileset.texWidth, ty + this.tileset.texHeight,
+            this.texVertices.push(
+                tx, ty + tileSize.y,
+                tx + tileSize.x, ty + tileSize.y,
                 tx, ty,
                 tx, ty,
-                tx + this.tileset.texWidth, ty + this.tileset.texHeight,
-                tx + this.tileset.texWidth, ty
+                tx + tileSize.x, ty + tileSize.y,
+                tx + tileSize.x, ty
             );
         });
     }


### PR DESCRIPTION
## Tileset refactor

**Margin and spacing** — now plain numbers instead of `Vector2`, with corrected semantics: `margin` is the space between the tiles and the four edges of the image, `spacing` is the separation between adjacent tiles. A tilesheet whose tiles are extruded by 1 px has `margin: 1` and `spacing: 2`.

**Tileset correction** — removed.

**Tileset width** — removed. The number of columns is derived from the image, so the user no longer provides it.

**Tileset processing** — everything `processTileset` computed is now cached on the tileset object (`_texData`) and calculated once instead of every frame, since the tileset cannot be updated at runtime. Texture vertices are emitted directly in texture coordinates, so the per-frame texture matrix scale is gone.

**Tile animations** — moved from the `TilemapRenderer` component to the `Tileset`. An animated tile is a property of the tileset image, not of a particular map. `TilemapAnimationSystem` now advances each unique tileset once per frame, so tilemaps sharing a tileset stay in sync instead of each ticking their own clock.

Docs updated in both languages, and the version is bumped to 2.3.4.

### Breaking changes

- `Tileset.width` no longer exists.
- `Tileset.margin` / `Tileset.spacing` are `number`, not `Vector2`.
- `TilemapRenderer.animations` moved to `Tileset.animations`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tilemap animations are now configured at the tileset level and remain synchronized across tilemaps.
  * Added support and documentation for extruded tilesets.
* **Improvements**
  * Simplified tileset configuration by removing the width requirement and using numeric margin and spacing values.
  * Improved tilemap rendering efficiency through cached texture information.
* **Documentation**
  * Updated English and Spanish tilemap, collider, and Tiled integration examples to reflect the new configuration.
* **Release**
  * Updated the Angry Pixel package to version 2.3.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->